### PR TITLE
Fixed typo in docs (EbuIo-PlugIt-NoTemplate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Medias are handled as usual, using the special `/media/` path.
 
 ### No template
 
-If you need to send back the result from the plugIt server directly to the client, without a template, you can set the `EbuIo-PlugIt-Redirect` header (to any value).
+If you need to send back the result from the plugIt server directly to the client, without a template, you can set the `EbuIo-PlugIt-NoTemplate` header (to any value).
 
 ## Session
 


### PR DESCRIPTION
It seems there's a typo in the docs: "EbuIo-PlugIt-Redirect" should be "EbuIo-PlugIt-NoTemplate" for direct rendering without a template.
