### PR TITLE
Add template blocks for css and javascript

### DIFF
--- a/examples/standalone_proxy/templates/plugIt/plugItBase-menu.html
+++ b/examples/standalone_proxy/templates/plugIt/plugItBase-menu.html
@@ -8,12 +8,22 @@
     <title>{% block title %}{% endblock %} :: PlugIt -Standalone mode</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+    {% block css %}
+    {#  CSS used on a specific page. #}
+    {#  use {{ block.super }} to avoid overwriting #}
     <link href="/media/css/bootstrap.min.css" rel="stylesheet" media="screen">
     <link href="/media/css/ionicons.min.css" rel="stylesheet" media="screen">
     <link href="/media/css/plugIt-standalone.css" rel="stylesheet" media="screen">
+    {% endblock %}
+    
+    
+    {% block javascript %}
+    {#  Javascript used on a specific page. #}
+    {#  use {{ block.super }} to avoid overwriting #}
     <script src="/media/js/jquery-2.1.4.min.js"></script>
     <script src="/media/js/bootstrap.min.js"></script>
-
+    {% endblock %}
+    
     <style>
         body { padding-top: 70px; } /* padding due to navbar top */
     </style>

--- a/examples/standalone_proxy/templates/plugIt/plugItBase.html
+++ b/examples/standalone_proxy/templates/plugIt/plugItBase.html
@@ -8,11 +8,20 @@
     <title>{% block title %}{% endblock %} :: PlugIt -Standalone mode</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+    {% block css %}
+    {#  CSS used on a specific page. #}
+    {#  use {{ block.super }} to avoid overwriting #}
     <link href="/media/css/bootstrap.min.css" rel="stylesheet" media="screen">
     <link href="/media/css/ionicons.min.css" rel="stylesheet" media="screen">
     <link href="/media/css/plugIt-standalone.css" rel="stylesheet" media="screen">
+    {% endblock %}
+    
+    {% block javascript %}
+    {#  Javascript used on a specific page. #}
+    {#  use {{ block.super }} to avoid overwriting #}
     <script src="/media/js/jquery-2.1.4.min.js"></script>
     <script src="/media/js/bootstrap.min.js"></script>
+    {% endblock %}
 
 </head>
 <body>


### PR DESCRIPTION
This Pull Request adds the ability to add <link> and <script> on the page <head> tag.