### PR TITLE
Fix proxy ssl redirection

### DIFF
--- a/plugit_proxy/views.py
+++ b/plugit_proxy/views.py
@@ -689,8 +689,8 @@ def main(request, query, hproPk=None, returnMenuOnly=False):
 
     # Check for SSL Requirements and redirect to ssl if necessary
     if hproject and hproject.plugItRequiresSsl:
-        if request._get_scheme() == 'http':
-            secure_url = request.build_absolute_uri(request.get_full_path()).replace('http://', 'https://')
+        if not request.is_secure():
+            secure_url = 'https://{0}{1}'.format(request.get_host(), request.get_full_path())
             return HttpResponsePermanentRedirect(secure_url)
 
     orgaMode = None

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 setup(
     name="plugit",
     packages=["plugit", "plugit_proxy"],
-    version="0.3.2",
+    version="0.3.3",
     license="BSD",
     description="PlugIt is a framework enhancing the portability and integration of web services requiring a user interface.",
     author="EBU Technology & Innovation",


### PR DESCRIPTION
When running behind  a reverse-proxy such as NGINX the X-Forwarded for options are not handled properly by `build_absolute_uri`. Thus we need to use `get_host` and `get_full_path`.

Additionally the localSettings.py of settings of the Django application need to have the following configuration options:

```python
# Setup support for proxy headers
USE_X_FORWARDED_HOST = True
SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
```