### PR TITLE
Qc improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.3.6
+
+Introduction of `send_etag` decorator, who allow to send an ETag header to the final client, using the `_plugit_etag` value in returned data.
+If an *action* return a 304, 401, 403, 404, 429 or 500 status code, the final code will be passed to the final client (before that, only a 200, 404 (for any code not in [200, 500]) or 500 was sent back).
+
+
 # v0.3.5
 
 Introduction of `X-Plugit-Remote-Addr` header, with the source IP of the user doing the request on the proxy side.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.3.5
+
+Introduction of `X-Plugit-Remote-Addr` header, with the source IP of the user doing the request on the proxy side.
+
 # v0.3.4
 
 Introduction of the `PI_USE_PROXY_IP` setting, allowing PlugIt services to do remote ip check behind a proxy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Introduction of `send_etag` decorator, who allow to send an ETag header to the f
 The `If-None-Match` http header is forwarded to the service, as `X-PlugIt-If-None_match`.
 If an *action* return a 304, 401, 403, 404, 429 or 500 status code, the final code will be passed to the final client (before that, only a 200, 404 (for any code not in [200, 500]) or 500 was sent back).
 The caching of the include tag has been improved.
+The Cache-Control header of media requests is forwarded to the client.
 
 
 # v0.3.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.3.6
 
 Introduction of `send_etag` decorator, who allow to send an ETag header to the final client, using the `_plugit_etag` value in returned data.
+The `If-None-Match` http header is forwarded to the service, as `X-PlugIt-If-None_match`.
 If an *action* return a 304, 401, 403, 404, 429 or 500 status code, the final code will be passed to the final client (before that, only a 200, 404 (for any code not in [200, 500]) or 500 was sent back).
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Introduction of `send_etag` decorator, who allow to send an ETag header to the final client, using the `_plugit_etag` value in returned data.
 The `If-None-Match` http header is forwarded to the service, as `X-PlugIt-If-None_match`.
 If an *action* return a 304, 401, 403, 404, 429 or 500 status code, the final code will be passed to the final client (before that, only a 200, 404 (for any code not in [200, 500]) or 500 was sent back).
+The caching of the include tag has been improved.
 
 
 # v0.3.5

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -25,6 +25,7 @@ It's possible to use various additional decorators to specify how the meta about
 * `@json_only`: Specifies the action return only json
 * `@xml_only`: Specifies the action return only xml (Response to have structure {'xml':'..'})
 * `@no_template`: Specifies no master template should be used
+* `@send_etag`: Specifiy that, when execution the action, the `_plugit_etag` value should be send back in `ETag` header and not as data.
 
 Again, the server.py file takes care of responding to /meta/, /template/ and /action/ call. The function in actions.py will be called when needed. The request is passed as the first parameters to actions.
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -63,7 +63,7 @@ The `ETag` header will be send back to the client.
 If this method return a 304, 401, 403, 404, 429 or 500 http status code the exact status code will be send back to the client. In others cases, if the status code is not 200, a 404 will be returned.
 
 ### /media/_medianame_
-This call return a specific media on the service side. Each request on EBUio side on /media/* is forwarded to the service and returned to the client. No caching is used, but a 1 hour Cache-Control header is set by EBUio-
+This call return a specific media on the service side. Each request on EBUio side on /media/* is forwarded to the service and returned to the client. No caching is used, but the Cache-Control header is forwarded by EBUio-
 
 ## API
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -73,6 +73,11 @@ It's possible to send mail using the API. All users reply to the mail, if keepin
 
 The management task check_mail is used to check mails and should be runned inside a cron job on the PlugIt Service. Relevent configuration (`INCOMING_MAIL` and `MAIL_SENDER`) should also be correct.
 
+### Extra headers
+
+The PlugIt Proxy will send extra information about the client using HTTP headers. All headers begin by `X-Plugit-`.
+
+* `X-Plugit-Remote-Addr`: The ip of the client doing the request.
 
 ### ProxyMode
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -82,6 +82,7 @@ The management task check_mail is used to check mails and should be runned insid
 The PlugIt Proxy will send extra information about the client using HTTP headers. All headers begin by `X-Plugit-`.
 
 * `X-Plugit-Remote-Addr`: The ip of the client doing the request.
+* `X-Plugit-If-None-Match`: The If-None-Match header value of the client doing the request.
 
 ### ProxyMode
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -58,6 +58,10 @@ It's possible to redirect the client using the header `EbuIo-PlugIt-Redirect`. P
 
 It's possible to send a file using the header `EbuIo-PlugIt-ItAFile`. The content is send to the user, using the same content-type. If any, the Content-Disposition header is also forwarder.
 
+The `ETag` header will be send back to the client.
+
+If this method return a 304, 401, 403, 404, 429 or 500 http status code the exact status code will be send back to the client. In others cases, if the status code is not 200, a 404 will be returned.
+
 ### /media/_medianame_
 This call return a specific media on the service side. Each request on EBUio side on /media/* is forwarded to the service and returned to the client. No caching is used, but a 1 hour Cache-Control header is set by EBUio-
 

--- a/examples/standalone_proxy/plugIt/templates/plugIt/plugItBase-common.html
+++ b/examples/standalone_proxy/plugIt/templates/plugIt/plugItBase-common.html
@@ -140,5 +140,8 @@
                 </div>
             </div>
         {% endblock %}
+        <script type="text/javascript">
+            $('[data-toggle="tooltip"]').tooltip();
+        </script>
     </body>
 </html>

--- a/plugit/api.py
+++ b/plugit/api.py
@@ -136,7 +136,7 @@ class PlugItAPI(object):
 
         retour = []
 
-        for data in r.json()['data']:
+        for data in r.json().get('data', []):
             retour.append(data)
 
         return retour

--- a/plugit/utils.py
+++ b/plugit/utils.py
@@ -81,6 +81,14 @@ def address_in_networks(networks):
     return real_decorator
 
 
+def send_etag():
+    """Decorator to specify that in data returned, '_plugit_etag' shouldn't be send back as data but in etag header"""
+    def real_decorator(function):
+        function.pi_api_send_etag = True
+        return function
+    return real_decorator
+
+
 def user_info(props):
     """Decorator to specify a list of properties requested about the current user"""
     def real_decorator(function):

--- a/plugit/views.py
+++ b/plugit/views.py
@@ -81,6 +81,12 @@ class ActionView(View):
             for (key, value) in headers.items():
                 response.headers['EbuIo-PlugIt-SetSession-' + key] = value
 
+            if hasattr(self.action, 'pi_api_send_etag'):
+                if result:
+                    etag = result.pop('_plugit_etag', None)
+                    if etag:
+                        response.headers['ETag'] = etag
+
         # Is it a redirect ?
         if isinstance(result, PlugItRedirect):
             response = make_response("")

--- a/plugit_proxy/plugIt.py
+++ b/plugit_proxy/plugIt.py
@@ -156,9 +156,14 @@ class PlugIt():
             if 'content-type' in r.headers:
                 content_type = r.headers['content-type']
 
-            return (r.content, content_type)
+            cache_control = None
+
+            if 'cache-control' in r.headers:
+                cache_control = r.headers['cache-control']
+
+            return (r.content, content_type, cache_control)
         else:
-            return (None, None)
+            return (None, None, None)
 
     def getMeta(self, uri):
         """Return meta information about an action. Cache the result as specified by the server"""

--- a/plugit_proxy/plugIt.py
+++ b/plugit_proxy/plugIt.py
@@ -192,7 +192,14 @@ class PlugIt():
         """Return the template for an action. Cache the result. Can use an optional meta parameter with meta information"""
 
         if not meta:
-            meta = self.getMeta(uri)
+
+            metaKey = self.cacheKey + '_templatesmeta_cache_' + uri
+
+            meta = cache.get(metaKey, None)
+
+            if not meta:
+                meta = self.getMeta(uri)
+                cache.set(metaKey, meta, 15)
 
         if not meta:  # No meta, can return a template
             return None

--- a/plugit_proxy/views.py
+++ b/plugit_proxy/views.py
@@ -405,8 +405,6 @@ def build_extra_headers(request, proxyMode, orgaMode, currentOrga):
     # If in proxymode, add needed infos to headers
     if proxyMode:
 
-        things_to_add = {}
-
         # User
         for prop in settings.PIAPI_USERDATA:
             if hasattr(request.user, prop):
@@ -420,6 +418,9 @@ def build_extra_headers(request, proxyMode, orgaMode, currentOrga):
 
         # General
         things_to_add['base_url'] = baseURI
+
+    if request and hasattr(request, 'META') and 'REMOTE_ADDR' in request.META:
+        things_to_add['remote-addr'] = request.META['REMOTE_ADDR']
 
     return things_to_add
 

--- a/plugit_proxy/views.py
+++ b/plugit_proxy/views.py
@@ -875,14 +875,14 @@ def _get_subscription_labels(user, hproject):
 
 @cache_control(public=True, max_age=3600)
 def media(request, path, hproPk=None):
-    """Ask the server for a media and return it to the client browser. Add cache headers of 1 hour"""
+    """Ask the server for a media and return it to the client browser. Forward cache headers"""
 
     if not settings.PIAPI_STANDALONE:
         (plugIt, baseURI, _) = getPlugItObject(hproPk)
     else:
         global plugIt, baseURI
 
-    (media, contentType) = plugIt.getMedia(path)
+    (media, contentType, cache_control) = plugIt.getMedia(path)
 
     if not media:  # No media returned
         raise Http404
@@ -890,6 +890,9 @@ def media(request, path, hproPk=None):
     response = HttpResponse(media)
     response['Content-Type'] = contentType
     response['Content-Length'] = len(media)
+
+    if cache_control:
+        response['Cache-Control'] = cache_control
 
     return response
 

--- a/plugit_proxy/views.py
+++ b/plugit_proxy/views.py
@@ -419,8 +419,11 @@ def build_extra_headers(request, proxyMode, orgaMode, currentOrga):
         # General
         things_to_add['base_url'] = baseURI
 
-    if request and hasattr(request, 'META') and 'REMOTE_ADDR' in request.META:
-        things_to_add['remote-addr'] = request.META['REMOTE_ADDR']
+    if request and hasattr(request, 'META'):
+        if 'REMOTE_ADDR' in request.META:
+            things_to_add['remote-addr'] = request.META['REMOTE_ADDR']
+        if 'HTTP_IF_NONE_MATCH' in request.META:
+            things_to_add['If-None-Match'] = request.META['HTTP_IF_NONE_MATCH']
 
     return things_to_add
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 setup(
     name="plugit",
     packages=["plugit", "plugit_proxy"],
-    version="0.3.4",
+    version="0.3.5",
     license="BSD",
     description="PlugIt is a framework enhancing the portability and integration of web services requiring a user interface.",
     author="EBU Technology & Innovation",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 setup(
     name="plugit",
     packages=["plugit", "plugit_proxy"],
-    version="0.3.5",
+    version="0.3.6",
     license="BSD",
     description="PlugIt is a framework enhancing the portability and integration of web services requiring a user interface.",
     author="EBU Technology & Innovation",

--- a/tests/helpers/flask_server/actions.py
+++ b/tests/helpers/flask_server/actions.py
@@ -1,3 +1,7 @@
+from flask import abort, Response
+import werkzeug
+
+
 import sys
 sys.path.append('../../../')
 
@@ -5,7 +9,7 @@ sys.path.append('../../../')
 import time
 
 
-from plugit.utils import action, cache, only_logged_user, only_member_user, only_admin_user, only_orga_member_user, only_orga_admin_user, user_info, json_only, no_template, PlugItRedirect, PlugItSendFile, PlugItSetSession, get_session_from_request, xml_only, public, address_in_networks
+from plugit.utils import action, cache, only_logged_user, only_member_user, only_admin_user, only_orga_member_user, only_orga_admin_user, user_info, json_only, no_template, PlugItRedirect, PlugItSendFile, PlugItSetSession, get_session_from_request, xml_only, public, address_in_networks, send_etag
 
 
 @action(route="/", template="home.html")
@@ -231,3 +235,41 @@ def test_get_orga(request):
 @action(route='/remote_addr', template="echo.html")
 def test_remote_addr(request):
     return {'echo': request.headers.get('X-Plugit-Remote-Addr')}
+
+
+@action(route='/generate_401', template="echo.html")
+def test_generate_401(request):
+    abort(401)
+
+
+@action(route='/generate_403', template="echo.html")
+def test_generate_403(request):
+    abort(403)
+
+
+@action(route='/generate_404', template="echo.html")
+def test_generate_404(request):
+    abort(404)
+
+
+@action(route='/generate_304', template="echo.html")
+def test_generate_304(request):
+
+    class NotModified(werkzeug.exceptions.HTTPException):
+        code = 304
+
+        def get_response(self, environment):
+            return Response(status=304)
+
+    abort(NotModified())
+
+
+@action(route='/generate_429', template="echo.html")
+def test_generate_429(request):
+    abort(429)
+
+
+@action(route='/etag', template="echo.html")
+@send_etag()
+def test_etag(request):
+    return {'_plugit_etag': 'this-is-an-etag', 'echo': '42'}

--- a/tests/helpers/flask_server/actions.py
+++ b/tests/helpers/flask_server/actions.py
@@ -226,3 +226,8 @@ def test_set_user(request):
 @no_template()
 def test_get_orga(request):
     return {}
+
+
+@action(route='/remote_addr', template="echo.html")
+def test_remote_addr(request):
+    return {'echo': request.headers.get('X-Plugit-Remote-Addr')}

--- a/tests/helpers/flask_server/actions.py
+++ b/tests/helpers/flask_server/actions.py
@@ -273,3 +273,9 @@ def test_generate_429(request):
 @send_etag()
 def test_etag(request):
     return {'_plugit_etag': 'this-is-an-etag', 'echo': '42'}
+
+
+@action(route='/if_none_match', template="echo.html")
+def test_if_none_match(request):
+    print(request.headers)
+    return {'echo': request.headers.get('X-PlugIt-If-None-Match')}

--- a/tests/proxy_external/test_proxy_with_service.py
+++ b/tests/proxy_external/test_proxy_with_service.py
@@ -420,3 +420,12 @@ class TestExternal(unittest.TestCase):
         assert(retour.status_code == 200)
         assert('ETag' in retour.headers)
         assert(retour.headers['ETag'] == 'this-is-an-etag')
+
+    def test_if_none_match(self):
+
+        k = str(uuid.uuid4())
+
+        retour = self.do_query('if_none_match', headers={'If-None-Match': k})
+
+        assert(retour)
+        assert(k in retour.text)

--- a/tests/proxy_external/test_proxy_with_service.py
+++ b/tests/proxy_external/test_proxy_with_service.py
@@ -394,3 +394,29 @@ class TestExternal(unittest.TestCase):
         retour = self.do_query('sendfile_external', 'POST', files={'testfile2': open('tests/helpers/flask_server/media/testfile2', 'rb')}, headers={'X-CSRFToken': csrf_token.cookies['csrftoken']})
         assert(retour)
         assert('ok' in retour.text)
+
+    def test_generate_special_code_429(self):
+        retour = self.do_query('generate_429')
+        assert(retour.status_code == 429)
+
+    def test_generate_special_code_404(self):
+        retour = self.do_query('generate_404')
+        assert(retour.status_code == 404)
+
+    def test_generate_special_code_403(self):
+        retour = self.do_query('generate_403')
+        assert(retour.status_code == 403)
+
+    def test_generate_special_code_401(self):
+        retour = self.do_query('generate_401')
+        assert(retour.status_code == 401)
+
+    def test_generate_special_code_304(self):
+        retour = self.do_query('generate_304')
+        assert(retour.status_code == 304)
+
+    def test_send_etag(self):
+        retour = self.do_query('etag')
+        assert(retour.status_code == 200)
+        assert('ETag' in retour.headers)
+        assert(retour.headers['ETag'] == 'this-is-an-etag')

--- a/tests/proxy_external/test_proxy_with_service.py
+++ b/tests/proxy_external/test_proxy_with_service.py
@@ -76,6 +76,13 @@ class TestExternal(unittest.TestCase):
         assert(retour)
         assert('home_template' in retour.text)
 
+    def test_remote_addr_header(self):
+
+        retour = self.do_query('remote_addr')
+
+        assert(retour)
+        assert('127.0.0.1' in retour.text)
+
     def test_only_logged_user_ano(self):
         self.do_query('ebuio_setUser?mode=ano')
 

--- a/tests/proxy_internal/test_plugit.py
+++ b/tests/proxy_internal/test_plugit.py
@@ -103,21 +103,23 @@ class TestPlugIt(TestBase):
 
         media = str(uuid.uuid4())
 
-        data, content_type = self.plugIt.getMedia(media)
+        data, content_type, cache_control = self.plugIt.getMedia(media)
 
         assert(data == '{}')
         assert(content_type == 'application/octet-stream')
         assert(self.lastDoQueryCall['url'] == 'media/{}'.format(media))
+        assert(not cache_control)
 
-        self.plugIt.toReplyHeaders = lambda: {'content-type': 'test'}
+        self.plugIt.toReplyHeaders = lambda: {'content-type': 'test', 'cache-control': 'public, max-age=31536000'}
 
-        data, content_type = self.plugIt.getMedia(media)
+        data, content_type, cache_control = self.plugIt.getMedia(media)
 
         assert(data == '{}')
         assert(content_type == 'test')
+        assert(cache_control == 'public, max-age=31536000')
 
         self.plugIt.toReplyStatusCode = lambda: 201
-        data, content_type = self.plugIt.getMedia(media)
+        data, content_type, cache_control = self.plugIt.getMedia(media)
         assert(not data)
         assert(not content_type)
 

--- a/tests/proxy_internal/test_plugit.py
+++ b/tests/proxy_internal/test_plugit.py
@@ -200,7 +200,7 @@ class TestPlugIt(TestBase):
         self.plugIt.toReplyJson = lambda: {}
         self.plugIt.toReplyHeaders = lambda: {}
 
-        assert(self.plugIt.doAction(path) == ({}, {}))
+        assert(self.plugIt.doAction(path) == ({}, {}, {}))
         assert(self.lastDoQueryCall['url'] == 'action/{}'.format(path))
 
     def test_do_action_proxy_mode(self):
@@ -211,7 +211,7 @@ class TestPlugIt(TestBase):
         self.plugIt.toReplyJson = lambda: {}
         self.plugIt.toReplyHeaders = lambda: {}
 
-        assert(self.plugIt.doAction(path, proxyMode=True) == ("{}", {}))
+        assert(self.plugIt.doAction(path, proxyMode=True) == ("{}", {}, {}))
         assert(self.lastDoQueryCall['url'] == path)
 
     def test_do_action_proxy_mode_no_remplate(self):
@@ -222,7 +222,7 @@ class TestPlugIt(TestBase):
         self.plugIt.toReplyJson = lambda: {'k': k}
         self.plugIt.toReplyHeaders = lambda: {'ebuio-plugit-notemplate': True}
 
-        r, __ = self.plugIt.doAction('', proxyMode=True)
+        r, __, __ = self.plugIt.doAction('', proxyMode=True)
 
         assert(r.__class__.__name__ == 'PlugItNoTemplate')
         assert(json.loads(r.content)['k'] == k)
@@ -236,7 +236,7 @@ class TestPlugIt(TestBase):
         self.plugIt.toReplyJson = lambda: {'k': k}
         self.plugIt.toReplyHeaders = lambda: {}
 
-        assert(self.plugIt.doAction(path) == ({'k': k}, {}))
+        assert(self.plugIt.doAction(path) == ({'k': k}, {}, {}))
 
     def test_do_action_500(self):
         self.plugIt.toReplyStatusCode = lambda: 500
@@ -244,7 +244,21 @@ class TestPlugIt(TestBase):
 
     def test_do_action_fail(self):
         self.plugIt.toReplyStatusCode = lambda: 501
-        assert(self.plugIt.doAction('') == (None, {}))
+        assert(self.plugIt.doAction('') == (None, {}, {}))
+
+    def test_do_action_special_codes(self):
+
+        special_codes = [429, 404, 403, 401, 304]
+
+        for x in range(200, 500):
+            self.plugIt.toReplyStatusCode = lambda: x
+            r, __, __ = self.plugIt.doAction('')
+
+            if x in special_codes:
+                assert(r.__class__.__name__ == 'PlugItSpecialCode')
+                assert(r.code == x)
+            else:
+                assert(r.__class__.__name__ != 'PlugItSpecialCode')
 
     def test_do_action_session(self):
 
@@ -253,7 +267,7 @@ class TestPlugIt(TestBase):
         self.plugIt.toReplyStatusCode = lambda: 200
         self.plugIt.toReplyJson = lambda: {}
         self.plugIt.toReplyHeaders = lambda: {'Ebuio-PlugIt-SetSession-k': k}
-        assert(self.plugIt.doAction('') == ({}, {'k': k}))
+        assert(self.plugIt.doAction('') == ({}, {'k': k}, {}))
 
     def test_do_action_redirect(self):
 
@@ -262,11 +276,12 @@ class TestPlugIt(TestBase):
         self.plugIt.toReplyStatusCode = lambda: 200
         self.plugIt.toReplyJson = lambda: {}
         self.plugIt.toReplyHeaders = lambda: {'ebuio-plugit-redirect': k}
-        r, headers = self.plugIt.doAction('')
+        r, session, headers = self.plugIt.doAction('')
 
         assert(r.__class__.__name__ == 'PlugItRedirect')
         assert(r.url == k)
         assert(not r.no_prefix)
+        assert(session == {})
         assert(headers == {})
 
     def test_do_action_redirect_noprefix(self):
@@ -276,11 +291,12 @@ class TestPlugIt(TestBase):
         self.plugIt.toReplyStatusCode = lambda: 200
         self.plugIt.toReplyJson = lambda: {}
         self.plugIt.toReplyHeaders = lambda: {'ebuio-plugit-redirect': k, 'ebuio-plugit-redirect-noprefix': "True"}
-        r, headers = self.plugIt.doAction('')
+        r, session, headers = self.plugIt.doAction('')
 
         assert(r.__class__.__name__ == 'PlugItRedirect')
         assert(r.url == k)
         assert(r.no_prefix)
+        assert(session == {})
         assert(headers == {})
 
     def test_do_action_file(self):
@@ -292,14 +308,26 @@ class TestPlugIt(TestBase):
         self.plugIt.toReplyStatusCode = lambda: 200
         self.plugIt.toReplyJson = lambda: {'k': k}
         self.plugIt.toReplyHeaders = lambda: {'ebuio-plugit-itafile': k, 'Content-Type': content_type}
-        r, headers = self.plugIt.doAction('')
+        r, session, headers = self.plugIt.doAction('')
 
         assert(r.__class__.__name__ == 'PlugItFile')
         assert(json.loads(r.content)['k'] == k)
         assert(r.content_type == content_type)
         assert(r.content_disposition == '')
+        assert(session == {})
         assert(headers == {})
 
         self.plugIt.toReplyHeaders = lambda: {'ebuio-plugit-itafile': k, 'Content-Type': content_type, 'content-disposition': content_disposition}
-        r, headers = self.plugIt.doAction('')
+        r, __, __ = self.plugIt.doAction('')
         assert(r.content_disposition == content_disposition)
+
+    def test_do_action_etag(self):
+
+        k = str(uuid.uuid4())
+
+        self.plugIt.toReplyStatusCode = lambda: 200
+        self.plugIt.toReplyJson = lambda: {}
+        self.plugIt.toReplyHeaders = lambda: {'ETag': k}
+        r, session, headers = self.plugIt.doAction('')
+
+        assert(headers == {'ETag': k})

--- a/tests/proxy_internal/test_proxyviews_misc.py
+++ b/tests/proxy_internal/test_proxyviews_misc.py
@@ -218,6 +218,7 @@ class TestProxyViewsMisc(TestProxyViews):
         k = str(uuid.uuid4())
         uri = self.random_base_url()
         remote = str(uuid.uuid4())
+        if_none_match = str(uuid.uuid4())
 
         assert(not self.views.build_extra_headers(None, False, False, None))
 
@@ -229,13 +230,14 @@ class TestProxyViewsMisc(TestProxyViews):
         r = self.factory.get('/')
         r.user = U()
         r.user.k = k
-        r.META = {'REMOTE_ADDR': remote}
+        r.META = {'REMOTE_ADDR': remote, 'HTTP_IF_NONE_MATCH': if_none_match}
 
         headers = self.views.build_extra_headers(r, True, False, None)
 
         assert(headers['user_k'] == k)
         assert(headers['base_url'] == uri)
         assert(headers['remote-addr'] == remote)
+        assert(headers['If-None-Match'] == if_none_match)
         assert('orga_pk' not in headers)
         assert('orga_name' not in headers)
         assert('orga_codops' not in headers)

--- a/tests/proxy_internal/test_proxyviews_misc.py
+++ b/tests/proxy_internal/test_proxyviews_misc.py
@@ -217,6 +217,7 @@ class TestProxyViewsMisc(TestProxyViews):
 
         k = str(uuid.uuid4())
         uri = self.random_base_url()
+        remote = str(uuid.uuid4())
 
         assert(not self.views.build_extra_headers(None, False, False, None))
 
@@ -228,11 +229,13 @@ class TestProxyViewsMisc(TestProxyViews):
         r = self.factory.get('/')
         r.user = U()
         r.user.k = k
+        r.META = {'REMOTE_ADDR': remote}
 
         headers = self.views.build_extra_headers(r, True, False, None)
 
         assert(headers['user_k'] == k)
         assert(headers['base_url'] == uri)
+        assert(headers['remote-addr'] == remote)
         assert('orga_pk' not in headers)
         assert('orga_name' not in headers)
         assert('orga_codops' not in headers)

--- a/tests/service_external/test_service_from_http.py
+++ b/tests/service_external/test_service_from_http.py
@@ -316,6 +316,13 @@ class TestExternal(unittest.TestCase):
         assert(not self.do_query('template/tralala'))
         assert(not self.do_query('meta/tralala'))
 
+    def test_etag(self):
+        r = self.do_query('action/etag')
+
+        assert(r)
+        assert('ETag' in r.headers)
+        assert(r.headers['ETag'] == 'this-is-an-etag')
+
     def test_baseurl(self):
         self.start_p(['baseurl'])
 

--- a/tests/service_internal/test_utils.py
+++ b/tests/service_internal/test_utils.py
@@ -169,6 +169,16 @@ class TestUtils(TestBase):
 
         assert(_tmp.pi_api_no_template)
 
+    def test_decorators_send_etag(self):
+        """Test the send_etag decorator"""
+        from plugit.utils import send_etag
+
+        @send_etag()
+        def _tmp():
+            pass
+
+        assert(_tmp.pi_api_send_etag)
+
     def test_md5checksum(self):
         """Test the md5Checksum util"""
         import tempfile


### PR DESCRIPTION
This should be merged after #59 

* The plugit proxy and service are now able to handle and forward the ETag header (via a new decorator for the service)
* The 304, 401, 403, and 429 status code are now forwarded to the client instead of returning a 404.

The last changes are in theory not backward compatible to previous behavior of the PlugIt proxy in those cases. But I don't think it will broke any service, since it's more on the new feature side than a breaking change. I don't think any service use those codes.

This should allow QC to use the ETag Header (Etag + 304) and return a 429 instead of a 404 in case of API's rate limiting.
